### PR TITLE
Change cartservice external database calls to be separate spans

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -59,8 +59,10 @@ spec:
           value: "0.33"
         - name: EXTERNAL_DB_NAME
           value: "Galactus.Postgres"
-        - name: EXTERNAL_DB_CHANGE_RATE
-          value: "0.50"
+        - name: EXTERNAL_DB_ACCESS_RATE
+          value: "0.75"
+        - name: EXTERNAL_DB_MAX_DURATION_MILLIS
+          value: "1500"
         resources:
           requests:
             cpu: 200m

--- a/src/cartservice/Program.cs
+++ b/src/cartservice/Program.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-﻿using System;
+using System;
 using System.IO;
 using System.Diagnostics;
 using System.Threading;
@@ -28,190 +28,194 @@ using StackExchange.Redis;
 
 namespace cartservice
 {
-    class Program
+  class Program
+  {
+    const string CART_SERVICE_ADDRESS = "LISTEN_ADDR";
+    const string REDIS_ADDRESS = "REDIS_ADDR";
+    const string CART_SERVICE_PORT = "PORT";
+    private const int REDIS_RETRY_NUM = 5;
+
+    public static TracerProvider tracerProvider;
+
+    [Verb("start", HelpText = "Starts the server listening on provided port")]
+    class ServerOptions
     {
-        const string CART_SERVICE_ADDRESS = "LISTEN_ADDR";
-        const string REDIS_ADDRESS = "REDIS_ADDR";
-        const string CART_SERVICE_PORT = "PORT";
-        private const int REDIS_RETRY_NUM = 5;
+      [Option('h', "hostname", HelpText = "The ip on which the server is running. If not provided, LISTEN_ADDR environment variable value will be used. If not defined, localhost is used")]
+      public string Host { get; set; }
 
-        [Verb("start", HelpText = "Starts the server listening on provided port")]
-        class ServerOptions
+      [Option('p', "port", HelpText = "The port on for running the server")]
+      public int Port { get; set; }
+
+      [Option('r', "redis", HelpText = "The ip of redis cache")]
+      public string Redis { get; set; }
+    }
+
+
+    static object StartServer(string host, int port, ICartStore cartStore)
+    {
+      // Run the server in a separate thread and make the main thread busy waiting.
+      // The busy wait is because when we run in a container, we can't use techniques such as waiting on user input (Console.Readline())
+      Task serverTask = Task.Run(async () =>
+      {
+        try
         {
-            [Option('h', "hostname", HelpText = "The ip on which the server is running. If not provided, LISTEN_ADDR environment variable value will be used. If not defined, localhost is used")]
-            public string Host { get; set; }
+          await cartStore.InitializeAsync();
 
-            [Option('p', "port", HelpText = "The port on for running the server")]
-            public int Port { get; set; }
-
-            [Option('r', "redis", HelpText = "The ip of redis cache")]
-            public string Redis { get; set; }
-        }
-
-
-        static object StartServer(string host, int port, ICartStore cartStore)
-        {
-            // Run the server in a separate thread and make the main thread busy waiting.
-            // The busy wait is because when we run in a container, we can't use techniques such as waiting on user input (Console.Readline())
-            Task serverTask = Task.Run(async () =>
-            {
-                try
-                {
-                    await cartStore.InitializeAsync();
-
-                    Console.WriteLine($"Trying to start a grpc server at  {host}:{port}");
-                    Server server = new Server
-                    {
-                        Services =
-                        {
+          Console.WriteLine($"Trying to start a grpc server at  {host}:{port}");
+          Server server = new Server
+          {
+            Services =
+                  {
                             // Cart Service Endpoint
                              Hipstershop.CartService.BindService(new CartServiceImpl(cartStore)),
 
                              // Health Endpoint
                              Grpc.Health.V1.Health.BindService(new HealthImpl(cartStore))
-                        },
-                        Ports = { new ServerPort(host, port, ServerCredentials.Insecure) }
-                    };
+                  },
+            Ports = { new ServerPort(host, port, ServerCredentials.Insecure) }
+          };
 
-                    Console.WriteLine($"Cart server is listening at {host}:{port}");
-                    server.Start();
+          Console.WriteLine($"Cart server is listening at {host}:{port}");
+          server.Start();
 
-                    Console.WriteLine("Initialization completed");
+          Console.WriteLine("Initialization completed");
 
-                    // Keep the server up and running
-                    while(true)
-                    {
-                        Thread.Sleep(TimeSpan.FromMinutes(10));
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine(ex);
-                }
-            });
-
-            return Task.WaitAny(new[] { serverTask });
+          // Keep the server up and running
+          while (true)
+          {
+            Thread.Sleep(TimeSpan.FromMinutes(10));
+          }
         }
-
-        static void Main(string[] args)
+        catch (Exception ex)
         {
-            if (args.Length == 0)
-            {
-                Console.WriteLine("Invalid number of arguments supplied");
-                Environment.Exit(-1);
-            }
-
-            switch (args[0])
-            {
-                case "start":
-                    Parser.Default.ParseArguments<ServerOptions>(args).MapResult(
-                        (ServerOptions options) =>
-                        {
-                            var redis = NewRedisConnection(options.Redis);
-                            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                                .AddSource("opentelemetry.dotnet")
-                                .AddRedisInstrumentation(redis)
-                                .AddProcessor(new AttrMappingProcessor())
-                                .AddZipkinExporter(o =>
-                                {
-                                    o.ServiceName = "cartservice";
-                                    o.Endpoint = new Uri(Environment.GetEnvironmentVariable("SIGNALFX_ENDPOINT_URL"));
-                                })
-                                .Build();
-                            Console.WriteLine($"Started as process with id {System.Diagnostics.Process.GetCurrentProcess().Id}");
-
-                            // Set hostname/ip address
-                            string hostname = options.Host;
-                            if (string.IsNullOrEmpty(hostname))
-                            {
-                                Console.WriteLine($"Reading host address from {CART_SERVICE_ADDRESS} environment variable");
-                                hostname = Environment.GetEnvironmentVariable(CART_SERVICE_ADDRESS);
-                                if (string.IsNullOrEmpty(hostname))
-                                {
-                                    Console.WriteLine($"Environment variable {CART_SERVICE_ADDRESS} was not set. Setting the host to 0.0.0.0");
-                                    hostname = "0.0.0.0";
-                                }
-                            }
-
-                            // Set the port
-                            int port = options.Port;
-                            if (options.Port <= 0)
-                            {
-                                Console.WriteLine($"Reading cart service port from {CART_SERVICE_PORT} environment variable");
-                                string portStr = Environment.GetEnvironmentVariable(CART_SERVICE_PORT);
-                                if (string.IsNullOrEmpty(portStr))
-                                {
-                                    Console.WriteLine($"{CART_SERVICE_PORT} environment variable was not set. Setting the port to 8080");
-                                    port = 8080;
-                                }
-                                else
-                                {
-                                    port = int.Parse(portStr);
-                                }
-                            }
-
-                            // Set redis cache host (hostname+port)
-                            ICartStore cartStore;
-
-                            // Redis was specified via command line or environment variable
-                            // If you want to start cart store using local cache in process, you can replace the following line with this:
-                            // cartStore = new LocalCartStore();
-                            cartStore = new RedisCartStore(redis);
-
-                            return StartServer(hostname, port, cartStore);
-                        },
-                        errs => 1);
-                    break;
-                default:
-                    Console.WriteLine("Invalid command");
-                    break;
-            }
+          Console.WriteLine(ex);
         }
+      });
 
-        private static ConnectionMultiplexer NewRedisConnection(string address)
-        {
-            address = ReadRedisAddress(address); 
-            var connectionString = $"{address},ssl=false,allowAdmin=true,connectRetry=5";
-            var redisConnectionOptions = ConfigurationOptions.Parse(connectionString);
-
-            // Try to reconnect if first retry failed (up to 5 times with exponential backoff)
-            redisConnectionOptions.ConnectRetry = REDIS_RETRY_NUM;
-            redisConnectionOptions.ReconnectRetryPolicy = new ExponentialRetry(100);
-
-            redisConnectionOptions.KeepAlive = 180;
-
-            Console.WriteLine("Connecting to Redis: " + connectionString);
-            var redis = ConnectionMultiplexer.Connect(redisConnectionOptions);
-
-            // redis.InternalError += (o, e) => { Console.WriteLine(e.Exception); };
-
-            if (redis == null)
-            {
-                Console.WriteLine("Wasn't able to connect to redis");
-
-                // We weren't able to connect to redis despite 5 retries with exponential backoff
-                throw new ApplicationException("Wasn't able to connect to redis");
-            }
-
-            Console.WriteLine("Successfully connected to Redis");
-            return redis;
-        }
-
-        private static string ReadRedisAddress(string address)
-        {
-            if (!string.IsNullOrEmpty(address))
-            {
-                return address;
-            }
-
-            Console.WriteLine($"Reading redis cache address from environment variable {REDIS_ADDRESS}");
-            string redis = Environment.GetEnvironmentVariable(REDIS_ADDRESS);
-            if (!string.IsNullOrEmpty(redis))
-            {
-                return redis;
-            }
-
-            return null;
-        }
+      return Task.WaitAny(new[] { serverTask });
     }
+
+    static void Main(string[] args)
+    {
+      if (args.Length == 0)
+      {
+        Console.WriteLine("Invalid number of arguments supplied");
+        Environment.Exit(-1);
+      }
+
+      switch (args[0])
+      {
+        case "start":
+          Parser.Default.ParseArguments<ServerOptions>(args).MapResult(
+              (ServerOptions options) =>
+              {
+                var redis = NewRedisConnection(options.Redis);
+                tracerProvider = Sdk.CreateTracerProviderBuilder()
+                              .AddSource("opentelemetry.dotnet")
+                              .AddSource("cartservice")
+                              .AddRedisInstrumentation(redis)
+                              .AddProcessor(new AttrMappingProcessor())
+                            //   .AddConsoleExporter()
+                              .AddZipkinExporter(o =>
+                              {
+                                o.ServiceName = "cartservice";
+                                o.Endpoint = new Uri(Environment.GetEnvironmentVariable("SIGNALFX_ENDPOINT_URL"));
+                              })
+                              .Build();
+                Console.WriteLine($"Started as process with id {System.Diagnostics.Process.GetCurrentProcess().Id}");
+
+                // Set hostname/ip address
+                string hostname = options.Host;
+                if (string.IsNullOrEmpty(hostname))
+                {
+                  Console.WriteLine($"Reading host address from {CART_SERVICE_ADDRESS} environment variable");
+                  hostname = Environment.GetEnvironmentVariable(CART_SERVICE_ADDRESS);
+                  if (string.IsNullOrEmpty(hostname))
+                  {
+                    Console.WriteLine($"Environment variable {CART_SERVICE_ADDRESS} was not set. Setting the host to 0.0.0.0");
+                    hostname = "0.0.0.0";
+                  }
+                }
+
+                // Set the port
+                int port = options.Port;
+                if (options.Port <= 0)
+                {
+                  Console.WriteLine($"Reading cart service port from {CART_SERVICE_PORT} environment variable");
+                  string portStr = Environment.GetEnvironmentVariable(CART_SERVICE_PORT);
+                  if (string.IsNullOrEmpty(portStr))
+                  {
+                    Console.WriteLine($"{CART_SERVICE_PORT} environment variable was not set. Setting the port to 8080");
+                    port = 8080;
+                  }
+                  else
+                  {
+                    port = int.Parse(portStr);
+                  }
+                }
+
+                // Set redis cache host (hostname+port)
+                ICartStore cartStore;
+
+                // Redis was specified via command line or environment variable
+                // If you want to start cart store using local cache in process, you can replace the following line with this:
+                // cartStore = new LocalCartStore();
+                cartStore = new RedisCartStore(redis);
+
+                return StartServer(hostname, port, cartStore);
+              },
+              errs => 1);
+          break;
+        default:
+          Console.WriteLine("Invalid command");
+          break;
+      }
+    }
+
+    private static ConnectionMultiplexer NewRedisConnection(string address)
+    {
+      address = ReadRedisAddress(address);
+      var connectionString = $"{address},ssl=false,allowAdmin=true,connectRetry=5";
+      var redisConnectionOptions = ConfigurationOptions.Parse(connectionString);
+
+      // Try to reconnect if first retry failed (up to 5 times with exponential backoff)
+      redisConnectionOptions.ConnectRetry = REDIS_RETRY_NUM;
+      redisConnectionOptions.ReconnectRetryPolicy = new ExponentialRetry(100);
+
+      redisConnectionOptions.KeepAlive = 180;
+
+      Console.WriteLine("Connecting to Redis: " + connectionString);
+      var redis = ConnectionMultiplexer.Connect(redisConnectionOptions);
+
+      // redis.InternalError += (o, e) => { Console.WriteLine(e.Exception); };
+
+      if (redis == null)
+      {
+        Console.WriteLine("Wasn't able to connect to redis");
+
+        // We weren't able to connect to redis despite 5 retries with exponential backoff
+        throw new ApplicationException("Wasn't able to connect to redis");
+      }
+
+      Console.WriteLine("Successfully connected to Redis");
+      return redis;
+    }
+
+    private static string ReadRedisAddress(string address)
+    {
+      if (!string.IsNullOrEmpty(address))
+      {
+        return address;
+      }
+
+      Console.WriteLine($"Reading redis cache address from environment variable {REDIS_ADDRESS}");
+      string redis = Environment.GetEnvironmentVariable(REDIS_ADDRESS);
+      if (!string.IsNullOrEmpty(redis))
+      {
+        return redis;
+      }
+
+      return null;
+    }
+  }
 }

--- a/src/cartservice/README.md
+++ b/src/cartservice/README.md
@@ -1,0 +1,9 @@
+# cartservice
+
+## Environment Variables
+
+`REDIS_SPAN_ERROR_RATE`: float [0, 1], Percentage of redis spans that will be flagged as an error
+
+`EXTERNAL_DB_NAME`: string, Name of external database
+`EXTERNAL_DB_ACCESS_RATE`: float [0, 1], Percentage of redis spans that will be turned into external database spans
+`EXTERNAL_DB_MAX_DURATION_MILLIS`: int, Artificial delay added to external database spans (mock value)


### PR DESCRIPTION
Adds artificial spans for an external database, which introduces a
little bit of real latency to the AddItem query as well. This replaces
the previous work of changing the existing redis spans into database
spans.