### PR TITLE
Remove cartservice postres errors by default

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -62,7 +62,7 @@ spec:
         - name: EXTERNAL_DB_MAX_DURATION_MILLIS
           value: "750"
         - name: EXTERNAL_DB_ERROR_RATE
-          value: "0.33"
+          value: "0.0"
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
We can still turn them on using the `EXTERNAL_DB_ERROR_RATE` during
runtime.