### PR TITLE
Upgrade splunk-otel-js to solve in progress context bug

### DIFF
--- a/src/currencyservice/package-lock.json
+++ b/src/currencyservice/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/instrumentation-dns": "^0.14.0",
         "@opentelemetry/instrumentation-grpc": "^0.18.0",
         "@opentelemetry/instrumentation-http": "^0.18.0",
-        "@splunk/otel": "^0.5.0",
+        "@splunk/otel": "^0.6.0",
         "async": "^1.5.2",
         "google-protobuf": "^3.9.2",
         "grpc": "^1.23.3",
@@ -309,9 +309,10 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@splunk/otel": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.5.0.tgz",
-      "integrity": "sha512-RSl+m3OeFSahhgw288gUaR1ERrWvc2GLhOHf/X2F3ofql1LHNqr4ti3H+TkDF+7z0pVjgglyl2qBLfkygDZ5hg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.6.0.tgz",
+      "integrity": "sha512-gpK1ZRaHerGkzYydXUVmfpjtb8L4q6n7qxn5jbaBYLCP5IvySvLJwwaZDl0qgolQnCUWeSHOvPzwKemLzifWhA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^0.18.0",
         "@opentelemetry/context-async-hooks": "^0.18.0",
@@ -4039,9 +4040,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@splunk/otel": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.5.0.tgz",
-      "integrity": "sha512-RSl+m3OeFSahhgw288gUaR1ERrWvc2GLhOHf/X2F3ofql1LHNqr4ti3H+TkDF+7z0pVjgglyl2qBLfkygDZ5hg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.6.0.tgz",
+      "integrity": "sha512-gpK1ZRaHerGkzYydXUVmfpjtb8L4q6n7qxn5jbaBYLCP5IvySvLJwwaZDl0qgolQnCUWeSHOvPzwKemLzifWhA==",
       "requires": {
         "@opentelemetry/api": "^0.18.0",
         "@opentelemetry/context-async-hooks": "^0.18.0",

--- a/src/currencyservice/package.json
+++ b/src/currencyservice/package.json
@@ -13,7 +13,7 @@
     "@opentelemetry/instrumentation-dns": "^0.14.0",
     "@opentelemetry/instrumentation-grpc": "^0.18.0",
     "@opentelemetry/instrumentation-http": "^0.18.0",
-    "@splunk/otel": "^0.5.0",
+    "@splunk/otel": "^0.6.0",
     "async": "^1.5.2",
     "google-protobuf": "^3.9.2",
     "grpc": "^1.23.3",

--- a/src/paymentservice/package-lock.json
+++ b/src/paymentservice/package-lock.json
@@ -11,7 +11,7 @@
         "@grpc/proto-loader": "^0.3.0",
         "@opentelemetry/instrumentation-dns": "^0.14.0",
         "@opentelemetry/instrumentation-grpc": "^0.18.0",
-        "@splunk/otel": "^0.5.0",
+        "@splunk/otel": "^0.6.0",
         "grpc": "^1.23.3",
         "pino": "^5.17.0",
         "simple-card-validator": "^1.1.0",
@@ -286,9 +286,10 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@splunk/otel": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.5.0.tgz",
-      "integrity": "sha512-RSl+m3OeFSahhgw288gUaR1ERrWvc2GLhOHf/X2F3ofql1LHNqr4ti3H+TkDF+7z0pVjgglyl2qBLfkygDZ5hg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.6.0.tgz",
+      "integrity": "sha512-gpK1ZRaHerGkzYydXUVmfpjtb8L4q6n7qxn5jbaBYLCP5IvySvLJwwaZDl0qgolQnCUWeSHOvPzwKemLzifWhA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^0.18.0",
         "@opentelemetry/context-async-hooks": "^0.18.0",
@@ -3606,9 +3607,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@splunk/otel": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.5.0.tgz",
-      "integrity": "sha512-RSl+m3OeFSahhgw288gUaR1ERrWvc2GLhOHf/X2F3ofql1LHNqr4ti3H+TkDF+7z0pVjgglyl2qBLfkygDZ5hg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-0.6.0.tgz",
+      "integrity": "sha512-gpK1ZRaHerGkzYydXUVmfpjtb8L4q6n7qxn5jbaBYLCP5IvySvLJwwaZDl0qgolQnCUWeSHOvPzwKemLzifWhA==",
       "requires": {
         "@opentelemetry/api": "^0.18.0",
         "@opentelemetry/context-async-hooks": "^0.18.0",

--- a/src/paymentservice/package.json
+++ b/src/paymentservice/package.json
@@ -14,7 +14,7 @@
     "@grpc/proto-loader": "^0.3.0",
     "@opentelemetry/instrumentation-dns": "^0.14.0",
     "@opentelemetry/instrumentation-grpc": "^0.18.0",
-    "@splunk/otel": "^0.5.0",
+    "@splunk/otel": "^0.6.0",
     "grpc": "^1.23.3",
     "pino": "^5.17.0",
     "simple-card-validator": "^1.1.0",


### PR DESCRIPTION
splunk-otel-js fixed an in-process context propagation bug which might have broken context propagation between services as well. Upgrading to 0.6 should resolve that.