### PR TITLE
updated sfx to otel for dotnet

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -46,7 +46,8 @@ spec:
               fieldPath: status.hostIP
         - name: SIGNALFX_ENDPOINT_URL 
           # value: "http://zipkin.default:9411/api/v2/spans"
-          value: "http://$(NODE_IP):9411/api/v2/spans"
+          # value: "http://$(NODE_IP):9411/api/v2/spans"
+          value: "$(NODE_IP):6831"
         - name: SIGNALFX_SERVICE_NAME
           value: "cartservice"
         - name: SIGNALFX_SERVER_TIMING_CONTEXT

--- a/src/cartservice/AttributeMappingProcessor.cs
+++ b/src/cartservice/AttributeMappingProcessor.cs
@@ -14,9 +14,11 @@
 
 using System;
 using System.Diagnostics;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
 
-internal class AttrMappingProcessor : ActivityProcessor
+internal class AttrMappingProcessor : BaseProcessor<Activity>
 {
 
   public Random _random;

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="grpc.tools" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="0.5.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="0.5.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="0.5.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc3" />
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
   </ItemGroup>
 

--- a/src/cartservice/cartstore/RedisCartStore.cs
+++ b/src/cartservice/cartstore/RedisCartStore.cs
@@ -117,7 +117,7 @@ namespace cartservice.cartstore
       }
       catch (Exception ex)
       {
-        throw new RpcException(new Grpc.Core.Status(StatusCode.FailedPrecondition, $"Can't access cart storage. {ex}"));
+        throw new RpcException(new Grpc.Core.Status(Grpc.Core.StatusCode.FailedPrecondition, $"Can't access cart storage. {ex}"));
       }
     }
 
@@ -134,7 +134,7 @@ namespace cartservice.cartstore
       }
       catch (Exception ex)
       {
-        throw new RpcException(new Grpc.Core.Status(StatusCode.FailedPrecondition, $"Can't access cart storage. {ex}"));
+        throw new RpcException(new Grpc.Core.Status(Grpc.Core.StatusCode.FailedPrecondition, $"Can't access cart storage. {ex}"));
       }
     }
 
@@ -181,7 +181,7 @@ namespace cartservice.cartstore
       }
       catch (Exception ex)
       {
-        throw new RpcException(new Grpc.Core.Status(StatusCode.FailedPrecondition, $"Can't access cart storage. {ex}"));
+        throw new RpcException(new Grpc.Core.Status(Grpc.Core.StatusCode.FailedPrecondition, $"Can't access cart storage. {ex}"));
       }
     }
 


### PR DESCRIPTION
The only extra step required here is to open jaeger thrift udp on the otel-collector.
This is because 
a) ZipkinExporter doesn't read AddAttributes nor OTEL_RESOURCE_ATTRIBUTES
b) JaegerExporter also doesn't read OTEL_RESOURCE_ATTRIBUTES but it can read AddAttributes (for an environment) and it only sends over thrift udp atm

Once OTEL_RESOURCE_ATTRIBUTES is merged, we can revisit and use Zipkin instead.