### PR TITLE
update otel-go to use upstream to use env variables

### DIFF
--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -57,12 +57,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: SIGNALFX_ENDPOINT_URL
+          - name: OTEL_EXPORTER_JAEGER_ENDPOINT
             value: "http://$(NODE_IP):14268/api/traces"
-          - name: SIGNALFX_SERVICE_NAME 
-            value: "checkoutservice"
-          - name: JAEGER_SERVICE_NAME
-            value: "checkoutservice"
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=checkoutservice
           - name: MAX_RETRY_ATTEMPTS
             value: "20"
           - name: RETRY_INITIAL_SLEEP_MILLIS

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -78,12 +78,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: SIGNALFX_ENDPOINT_URL
+          - name: OTEL_EXPORTER_JAEGER_ENDPOINT
             value: "http://$(NODE_IP):14268/api/traces"
-          - name: SIGNALFX_SERVICE_NAME 
-            value: "frontendservice"
-          - name: JAEGER_SERVICE_NAME
-            value: "frontendservice"
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=frontendservice
           - name: SIGNALFX_SERVER_TIMING_CONTEXT
             value: "true"
           resources:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -40,12 +40,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: SIGNALFX_ENDPOINT_URL 
+        - name: OTEL_EXPORTER_JAEGER_ENDPOINT
           value: "http://$(NODE_IP):14268/api/traces"
-        - name: SIGNALFX_SERVICE_NAME 
-          value: "productcatalogservice"
-        - name: JAEGER_SERVICE_NAME
-          value: "productcatalogservice"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=productcatalogservice
           # value: "http://zipkin.default:9411/api/v2/spans"
         readinessProbe:
           exec:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -39,13 +39,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: SIGNALFX_ENDPOINT_URL 
+        - name: OTEL_EXPORTER_JAEGER_ENDPOINT
           value: "http://$(NODE_IP):14268/api/traces"
-        - name: SIGNALFX_SERVICE_NAME 
-          value: "shippingservice"
-        - name: JAEGER_SERVICE_NAME
-          value: "shippingservice"
-          # value: "http://zipkin.default:9411/api/v2/spans"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=shippingservice
         readinessProbe:
           periodSeconds: 5
           exec:

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -11,6 +11,10 @@ require (
 	github.com/signalfx/splunk-otel-go v0.0.0-20210331191121-59c68c77a30c
 	github.com/sirupsen/logrus v1.4.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.19.0
+	go.opentelemetry.io/contrib/propagators v0.19.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
 	go.opentelemetry.io/otel/trace v0.19.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	google.golang.org/grpc v1.36.0

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -24,14 +24,18 @@ import (
 
 	"cloud.google.com/go/profiler"
 	"github.com/google/uuid"
-	"github.com/signalfx/splunk-otel-go/distro"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/exporters/trace/jaeger"
+	"go.opentelemetry.io/contrib/propagators/b3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	pb "github.com/signalfx/microservices-demo/src/checkoutservice/genproto"
 	money "github.com/signalfx/microservices-demo/src/checkoutservice/money"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -116,6 +120,7 @@ func main() {
 	logger.Fatal(err)
 }
 
+/*
 func initTracing() func() {
 	sdk, err := distro.Run(distro.WithServiceName("checkoutservice"))
 	if err != nil {
@@ -129,6 +134,46 @@ func initTracing() func() {
 		}
 	}
 }
+*/
+
+func initTracing() func() {
+	endpoint := os.Getenv("OTEL_EXPORTER_JAEGER_ENDPOINT")
+	if endpoint == "" { endpoint = "localhost:14268/api/traces" }
+
+	exp, err := jaeger.NewRawExporter(
+				jaeger.WithCollectorEndpoint(endpoint),
+				)
+
+	if err != nil {
+		fmt.Errorf("%s: %v", "failed to create exporter", err)
+		os.Exit(1)
+	}
+	ctx := context.Background()
+	res, _ := resource.New(ctx)
+
+	traceProvider := sdktrace.NewTracerProvider(
+					sdktrace.WithSampler(sdktrace.AlwaysSample()),
+					sdktrace.WithResource(res),
+					sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(exp)),
+					)
+	otel.SetTracerProvider(traceProvider)
+	otel.SetTextMapPropagator(b3.B3{})
+
+	logger.Info("otel initialization completed.")
+	return func() {
+		err := traceProvider.Shutdown(ctx)
+		if err != nil {
+			fmt.Errorf("%s: %v", "failed to shutdown provider", err)
+			os.Exit(1)
+		}
+		err = exp.Shutdown(ctx)
+		if err != nil {
+			fmt.Errorf("%s: %v", "failed to stop exporter", err)
+			os.Exit(1)
+		}
+	}
+}
+
 
 func initProfiling(service, version string) {
 	// TODO(ahmetb) this method is duplicated in other microservices using Go

--- a/src/frontend/go.mod
+++ b/src/frontend/go.mod
@@ -14,6 +14,10 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.19.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.19.0
+	go.opentelemetry.io/contrib/propagators v0.19.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
 	go.opentelemetry.io/otel/trace v0.19.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	google.golang.org/grpc v1.36.0

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -11,6 +11,10 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.19.0
+	go.opentelemetry.io/contrib/propagators v0.19.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
 	go.opentelemetry.io/otel/trace v0.19.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	google.golang.org/grpc v1.36.0

--- a/src/shippingservice/go.mod
+++ b/src/shippingservice/go.mod
@@ -10,6 +10,10 @@ require (
 	github.com/signalfx/splunk-otel-go v0.0.0-20210331191121-59c68c77a30c
 	github.com/sirupsen/logrus v1.4.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.19.0
+	go.opentelemetry.io/contrib/propagators v0.19.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
 	go.opentelemetry.io/otel/trace v0.19.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	google.golang.org/grpc v1.36.0


### PR DESCRIPTION
Creating a new tracer from upstream otel so that we can use OTEL_RESOURCE_ATTRIBUTES to assign deployment.environment and service.name etc.