### PR TITLE
New /system-behavior api to control checkout failure rate

### DIFF
--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -62,10 +62,6 @@ spec:
           - name: SIGNALFX_ENDPOINT_URL 
             # value: "http://zipkin.default:9411/api/v2/spans"
             value: "http://$(NODE_IP):9411/api/v2/spans"
-          - name: MAX_RETRY_ATTEMPTS
-            value: "20"
-          - name: RETRY_INITIAL_SLEEP_MILLIS
-            value: "25"
           resources:
             requests:
               cpu: 100m

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -44,7 +44,7 @@ spec:
           # value: "http://zipkin.default:9411/api/v2/spans"
           value: "http://$(NODE_IP):9411/api/v2/spans"
         - name: API_TOKEN_FAILURE_RATE
-          value: "1.0"
+          value: "0.75"
         - name: SERIALIZATION_FAILURE_RATE
           value: "0.0"
         - name: SUCCESS_PAYMENT_SERVICE_DURATION_MILLIS

--- a/src/frontend/main.go
+++ b/src/frontend/main.go
@@ -138,6 +138,8 @@ func main() {
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./static/"))))
 	r.HandleFunc("/robots.txt", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "User-agent: *\nDisallow: /") })
 	r.HandleFunc("/_healthz", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "ok") })
+	r.HandleFunc("/system-behavior", svc.getSystemBehaviorHandler).Methods(http.MethodGet)
+	r.HandleFunc("/system-behavior", svc.patchSystemBehaviorHandler).Methods(http.MethodPatch)
 
 	var handler http.Handler = r
 	handler = &logHandler{log: log, next: handler} // add logging


### PR DESCRIPTION
Instead of relying on environment variables configured in the pods
to influence system behavior, it is not possible to configure some
behavior control from an API. The frontendservice maintains the
central set of behavior configurations and propagates these settings
during a request through an added `x-system-behavior` request header.

For now we only support configuring the checkoutservice behavior, but
the model is such that we could include future behavior controls as
well.

New supported apis:

`GET /system-behavior`
- returns the current system behavior settings

`PATCH /system-behavior`
- updates the provided settings for all subsequent requests

```
{
    "checkoutService": {
        "paymentFailureRate": 0,
        "maxRetryAttempts": 20,
        "retryInitialSleepMillis": 200
    }
}
```