### PR TITLE
Add bottleneck within photography ads and enable profiler

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -44,18 +44,16 @@ spec:
           env:
             - name: PORT
               value: '9555'
-            - name: OTEL_EXPORTER_ZIPKIN_SERVICE_NAME
+            - name: OTEL_SERVICE_NAME
               value: adservice
             - name: NODE_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER
-              value: zipkin
-            - name: JAVA_TOOL_OPTIONS
-              value: -javaagent:/opt/sfx/splunk-otel-javaagent-all.jar
-            - name: OTEL_EXPORTER_ZIPKIN_ENDPOINT
-              value: 'http://$(NODE_IP):9411/v1/trace'
+              value: otlp
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(NODE_IP):4317
           volumeMounts:
             - mountPath: /opt/sfx
               name: sfx-instrumentation

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=builder /app .
 ENV ENABLE_COPYRIGHT_CERTIFICATION=true
 
 EXPOSE 9555
-ENTRYPOINT ["/app/build/install/hipstershop/bin/AdService"]
+ENTRYPOINT ["/app/build/install/AdService/bin/AdService"]

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -22,5 +22,8 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
 WORKDIR /app
 COPY --from=builder /app .
 
+# Allow bottlenecks via copyright certification
+ENV ENABLE_COPYRIGHT_CERTIFICATION=true
+
 EXPOSE 9555
 ENTRYPOINT ["/app/build/install/hipstershop/bin/AdService"]

--- a/src/adservice/README.md
+++ b/src/adservice/README.md
@@ -26,3 +26,8 @@ From `src/adservice/`, run:
 docker build ./
 ```
 
+# Bottleneck support
+
+If you'd like to introduce a bottleneck, define `ENABLE_COPYRIGHT_CERTIFICATION=true` in the 
+environment.
+

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 description = 'Ad Service'
 group = "adservice"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 
 def grpcVersion = "1.42.1"
 def jacksonVersion = "2.12.5"
@@ -37,7 +37,8 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.14.1"
+                "org.apache.logging.log4j:log4j-core:2.14.1",
+                "javax.annotation:javax.annotation-api:1.3.2"
 
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -85,6 +85,7 @@ application {
     mainClassName = 'hipstershop.AdService'
     applicationName = 'AdService'
     applicationDefaultJvmArgs = [
+        "-Dotel.service.name=adservice",
         "-Dsplunk.profiler.enabled=true",
         "-Dsplunk.profiler.period.threaddump=1000"
     ]

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -107,7 +107,6 @@ task adServiceClient(type: CreateStartScripts) {
 }
 
 applicationDistribution.into('bin') {
-//    from(adService)
     from(adServiceClient)
     fileMode = 0755
 }

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.8'
     id 'idea'
     id 'application'
+    id 'com.ryandens.javaagent-application' version "0.2.1"
 }
 
 repositories {
@@ -43,6 +44,8 @@ dependencies {
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",
                 "io.netty:netty-tcnative-boringssl-static:2.0.43.Final"
+
+        javaagent "com.splunk:splunk-otel-javaagent:1.6.0:all"
     }
 }
 
@@ -78,7 +81,14 @@ sourceSets {
     }
 }
 
-startScripts.enabled = false
+application {
+    mainClassName = 'hipstershop.AdService'
+    applicationName = 'AdService'
+    applicationDefaultJvmArgs = [
+        "-Dsplunk.profiler.enabled=true",
+        "-Dsplunk.profiler.period.threaddump=1000"
+    ]
+}
 
 // This to cache dependencies during Docker image building. First build will take time.
 // Subsequent build will be incremental.
@@ -89,13 +99,6 @@ task downloadRepos(type: Copy) {
     into offlineCompile
 }
 
-task adService(type: CreateStartScripts) {
-    mainClassName = 'hipstershop.AdService'
-    applicationName = 'AdService'
-    outputDir = new File(project.buildDir, 'tmp')
-    classpath = startScripts.classpath
-}
-
 task adServiceClient(type: CreateStartScripts) {
     mainClassName = 'hipstershop.AdServiceClient'
     applicationName = 'AdServiceClient'
@@ -104,7 +107,7 @@ task adServiceClient(type: CreateStartScripts) {
 }
 
 applicationDistribution.into('bin') {
-    from(adService)
+//    from(adService)
     from(adServiceClient)
     fileMode = 0755
 }

--- a/src/adservice/src/main/java/hipstershop/AdService.java
+++ b/src/adservice/src/main/java/hipstershop/AdService.java
@@ -17,26 +17,26 @@
 package hipstershop;
 
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import hipstershop.Demo.Ad;
 import hipstershop.Demo.AdRequest;
 import hipstershop.Demo.AdResponse;
+import hipstershop.copyright.CopyrightCertification;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
-import io.grpc.services.*;
+import io.grpc.services.HealthStatusManager;
 import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public final class AdService {
 
@@ -49,6 +49,7 @@ public final class AdService {
   private HealthStatusManager healthMgr;
 
   private static final AdService service = new AdService();
+  private final CopyrightCertification copyrightCertification = new CopyrightCertification();
 
   private void start() throws IOException {
     int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "9555"));
@@ -135,7 +136,8 @@ public final class AdService {
   private static final ImmutableListMultimap<String, Ad> adsMap = createAdsMap();
 
   private Collection<Ad> getAdsByCategory(String category) {
-    return adsMap.get(category);
+    List<Ad> ads = adsMap.get(category);
+    return copyrightCertification.certify(category, ads);
   }
 
   private static final Random random = new Random();

--- a/src/adservice/src/main/java/hipstershop/copyright/BasicCertifier.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/BasicCertifier.java
@@ -1,0 +1,19 @@
+package hipstershop.copyright;
+
+import hipstershop.Demo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class BasicCertifier implements Certifier {
+    @Override
+    public List<Demo.Ad> certify(List<Demo.Ad> ads) {
+        List<Demo.Ad> result = new ArrayList<>(ads.size());
+        for (Demo.Ad ad : ads) {
+            if (!ad.getText().contains("©")) {
+                result.add(ad);
+            }
+        }
+        return result;
+    }
+}

--- a/src/adservice/src/main/java/hipstershop/copyright/Certifier.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/Certifier.java
@@ -1,0 +1,10 @@
+package hipstershop.copyright;
+
+import hipstershop.Demo;
+
+import java.util.List;
+
+// Filters a list of ads to only those that pass copyright certification
+interface Certifier {
+    List<Demo.Ad> certify(List<Demo.Ad> ads);
+}

--- a/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
@@ -7,6 +7,7 @@ import java.util.Map;
 public class CopyrightCertification {
 
     private final Map<String, Certifier> certifiers = new HashMap<>();
+    private final boolean enabled = Boolean.parseBoolean(System.getenv().getOrDefault("ENABLE_COPYRIGHT_CERTIFICATION", "false"));
 
     {
         certifiers.put("vintage", new BasicCertifier());
@@ -17,9 +18,10 @@ public class CopyrightCertification {
     }
 
     public List<hipstershop.Demo.Ad> certify(String category, List<hipstershop.Demo.Ad> ads) {
+        if(!enabled){
+            return ads;
+        }
         Certifier certifier = certifiers.get(category);
         return certifier.certify(ads);
     }
-
-
 }

--- a/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/CopyrightCertification.java
@@ -1,0 +1,25 @@
+package hipstershop.copyright;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CopyrightCertification {
+
+    private final Map<String, Certifier> certifiers = new HashMap<>();
+
+    {
+        certifiers.put("vintage", new BasicCertifier());
+        certifiers.put("cycling", new BasicCertifier());
+        certifiers.put("cookware", new BasicCertifier());
+        certifiers.put("photography", new PhotographyCertifier());
+        certifiers.put("gardening", new BasicCertifier());
+    }
+
+    public List<hipstershop.Demo.Ad> certify(String category, List<hipstershop.Demo.Ad> ads) {
+        Certifier certifier = certifiers.get(category);
+        return certifier.certify(ads);
+    }
+
+
+}

--- a/src/adservice/src/main/java/hipstershop/copyright/PhotographyCertifier.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/PhotographyCertifier.java
@@ -1,0 +1,22 @@
+package hipstershop.copyright;
+
+import hipstershop.Demo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class PhotographyCertifier implements Certifier {
+
+    private final StockPhotos stockPhotos = new StockPhotos();
+
+    @Override
+    public List<Demo.Ad> certify(List<Demo.Ad> ads) {
+        List<Demo.Ad> result = new ArrayList<>(ads.size());
+        for (Demo.Ad ad : ads) {
+            if(stockPhotos.isCopyright(ad)){
+               result.add(ad);
+            }
+        }
+        return result;
+    }
+}

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -22,7 +22,7 @@ public class StockPhotos {
 
     private static List<CopyrightPhoto> createDatabase() {
         List<CopyrightPhoto> result = new LinkedList<>();
-        for(int i=0; i < 20000; i++){
+        for(int i=0; i < 5000; i++){
             result.add(new CopyrightPhoto("photo" + i));
         }
         return result;

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -1,0 +1,50 @@
+package hipstershop.copyright;
+
+import hipstershop.Demo;
+
+import java.util.LinkedList;
+import java.util.List;
+
+// A massive repository of very many photos.
+public class StockPhotos {
+
+    private final static List<CopyrightPhoto> photos = createDatabase();
+
+    boolean isCopyright(Demo.Ad ad){
+        boolean result = true;
+        for (CopyrightPhoto photo : photos) {
+            if(photo.matchesAd(ad)){
+                result = false;
+            }
+        }
+        return result;
+    }
+
+    private static List<CopyrightPhoto> createDatabase() {
+        List<CopyrightPhoto> result = new LinkedList<>();
+        for(int i=0; i < 20000; i++){
+            result.add(new CopyrightPhoto("photo" + i));
+        }
+        return result;
+    }
+
+    static class CopyrightPhoto {
+
+        private final String id;
+
+        public CopyrightPhoto(String id) {
+            this.id = id;
+        }
+
+        public boolean matchesAd(Demo.Ad ad) {
+            boolean matches = false;
+            for (CopyrightPhoto photo : photos) {
+                if(photo.id.equals(ad.getRedirectUrl())){
+                    matches = true;
+                }
+            }
+            return matches;
+        }
+    }
+
+}

--- a/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
+++ b/src/adservice/src/main/java/hipstershop/copyright/StockPhotos.java
@@ -1,6 +1,9 @@
 package hipstershop.copyright;
 
+import hipstershop.AdService;
 import hipstershop.Demo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -8,13 +11,20 @@ import java.util.List;
 // A massive repository of very many photos.
 public class StockPhotos {
 
+    private final static long MAX_TIME_MS = 6500;
     private final static List<CopyrightPhoto> photos = createDatabase();
+    private static final Logger logger = LogManager.getLogger(AdService.class);
 
     boolean isCopyright(Demo.Ad ad){
         boolean result = true;
+        long start = System.currentTimeMillis();
         for (CopyrightPhoto photo : photos) {
             if(photo.matchesAd(ad)){
                 result = false;
+            }
+            if(System.currentTimeMillis() - start > MAX_TIME_MS){
+                logger.warn("Copyright check exceeded max threshold. Aborting.");
+                break;
             }
         }
         return result;


### PR DESCRIPTION
So if ads are requested for the `photography` context (category) then they will be slow. On my mac it's about 5.5s.

This is controlled by an environment var named `ENABLE_COPYRIGHT_CERTIFICATION`, which is disabled by default. However, the Dockerfile here has been changed to turn this _on_ by default.

I have confirmed that the Dockerfile can produce an image that contains the bottleneck.
This may not be complete -- may require collector endpoint to be changed/specified somewhere.