### PR TITLE
remove npm module from deployed containers

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -10,6 +10,8 @@ RUN npm install --only=production
 
 FROM base
 
+RUN rm -r /usr/local/lib/node_modules
+
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -10,6 +10,8 @@ RUN npm install --only=production
 
 FROM base
 
+RUN rm -r /usr/local/lib/node_modules
+
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe


### PR DESCRIPTION
A version of the 'ansi-regex' npm package vulnerable to [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807) is deployed as a dependency of the npm package manager and is causing the container to be marked as vulnerable. Since npm is not required in the deployed container, this commit removes npm from the image.