### PR TITLE
Fix cartservice ConfigHelper.GetBoolEnvVar

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -51,6 +51,8 @@ spec:
           value: "http://$(NODE_IP):9943/v2/datapoint"
         - name: SIGNALFX_PROFILER_ENABLED
           value: "true"
+        - name: SIGNALFX_PROFILER_CALL_STACK_INTERVAL
+          value: "1000"
         - name: SIGNALFX_PROFILER_LOGS_ENDPOINT
           value: "http://$(NODE_IP):4318/v1/logs"
         - name: SIGNALFX_RUNTIME_METRICS_ENABLED

--- a/src/cartservice/README.md
+++ b/src/cartservice/README.md
@@ -25,7 +25,6 @@ All these environment variables are boolean.
 - `FIX_EXCESSIVE_ALLOCATION`: bool, controls if the excessive allocation per request should be happening or not
 - `FIX_SLOW_LEAK`: bool, controls if a slowly growing memory leak is going to be happening or not
 - `OPTIMIZE_CPU`: bool, controls if  the CPU is going to be efficiently used during input validation
-
 - `OPTIMIZE_BLOCKING`: bool, controls if the code is going to do some blocking to retrieve a handle to the Redis DB
 
 ## Building and Testing Locally

--- a/src/cartservice/cartstore/ConfigHelper.cs
+++ b/src/cartservice/cartstore/ConfigHelper.cs
@@ -7,11 +7,15 @@ namespace cartservice.cartstore
     public static bool GetBoolEnvVar(string envVarName, bool defaultValue)
     {
       var varValue = Environment.GetEnvironmentVariable(envVarName) ?? string.Empty;
-      return varValue.ToLowerInvariant() switch
+      var result = varValue.ToLowerInvariant() switch
       {
         "true" or "1" or "yes" =>  true,
+        "false" or "0" or "no" =>  false,
         _ => defaultValue
       };
+
+      Console.WriteLine($"{nameof(ConfigHelper)}: env var {envVarName} = {result}");
+      return result;
     }
   }
 }

--- a/src/cartservice/cartstore/UserId.cs
+++ b/src/cartservice/cartstore/UserId.cs
@@ -46,7 +46,7 @@ namespace cartservice.cartstore
         }
 
         tmpChars.Add(c);
-        const int idealSizeForBogoSort = 10; // Not to fast, not to slow.
+        const int idealSizeForBogoSort = 10; // Not too fast, not too slow.
         if (tmpChars.Count == idealSizeForBogoSort)
         {
           Bogo.Sort(tmpChars);


### PR DESCRIPTION
There was a bug on ConfigHelper.GetBoolEnvVar. It "worked" as intended until during the PR we changed the defaults. Fixing this so we can leverage the OPTIMIZE_* env vars for demo scenarios. 
