### PR TITLE
Bump sfx-dotnet-tracing to 1.1.0

### DIFF
--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=builder /cartservice .
 COPY --from=builder /app/start .
 
 # Add the SFx.NET Instrumentation
-ARG TRACER_VERSION=1.0.1
+ARG TRACER_VERSION=1.1.0
 ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb ./
 
 RUN mkdir -p /var/log/signalfx


### PR DESCRIPTION
Update dockerfile to use the most recently released version of signalfx-dotnet-tracing.