### PR TITLE
[cartservice] switch to Splunk .NET OTel distribution

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -45,22 +45,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: SIGNALFX_ENDPOINT_URL
-          value: "http://$(NODE_IP):9411/api/v2/spans"
-        - name: SIGNALFX_METRICS_ENDPOINT_URL
-          value: "http://$(NODE_IP):9943/v2/datapoint"
-        - name: SIGNALFX_PROFILER_ENABLED
-          value: "true"
-        - name: SIGNALFX_PROFILER_CALL_STACK_INTERVAL
-          value: "1000"
-        - name: SIGNALFX_PROFILER_LOGS_ENDPOINT
-          value: "http://$(NODE_IP):4318/v1/logs"
-        - name: SIGNALFX_RUNTIME_METRICS_ENABLED
-          value: "true"
-        - name: SIGNALFX_SERVICE_NAME
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(NODE_IP):4318"
+        - name: OTEL_SERVICE_NAME
           value: "cartservice"
-        - name: SIGNALFX_ENV
-          value: "demo"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "deployment.environment=demo"
+        - name: OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES
+          value: "Cartservice"
         - name: EXTERNAL_DB_NAME
           value: "Galactus.Postgres"
         - name: EXTERNAL_DB_ACCESS_RATE

--- a/src/cartservice/ActivitySourceUtil.cs
+++ b/src/cartservice/ActivitySourceUtil.cs
@@ -1,0 +1,8 @@
+﻿using System.Diagnostics;
+
+namespace cartservice;
+
+public class ActivitySourceUtil
+{
+    public static ActivitySource ActivitySource = new ActivitySource("Cartservice");
+}

--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -22,21 +22,25 @@ WORKDIR /app
 COPY --from=builder /cartservice .
 COPY --from=builder /app/start .
 
-# Add the SFx.NET Instrumentation
-ARG TRACER_VERSION=1.1.0
-ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb ./
+# Add the Splunk Distribution of OpenTelemetry .NET
+RUN apt-get update && \
+    apt-get install -y \
+            curl \
+            unzip
 
-RUN mkdir -p /var/log/signalfx
-RUN mkdir -p /opt/signalfx
-RUN dpkg -i ./signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
-RUN rm ./signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
+ARG SPLUNK_OTEL_VERSION=0.2.0-beta.1
+ENV OTEL_DOTNET_AUTO_HOME=/.splunk-otel-dotnet
+ADD https://github.com/signalfx/splunk-otel-dotnet/releases/download/v${SPLUNK_OTEL_VERSION}/splunk-otel-dotnet-install.sh ./
+RUN chmod +x ./splunk-otel-dotnet-install.sh && \
+    ./splunk-otel-dotnet-install.sh && \
+    rm ./splunk-otel-dotnet-install.sh
 
 ENV CORECLR_ENABLE_PROFILING=1
-ENV CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
-ENV CORECLR_PROFILER_PATH=/opt/signalfx/SignalFx.Tracing.ClrProfiler.Native.so
-ENV SIGNALFX_DOTNET_TRACER_HOME=/opt/signalfx
-ENV SIGNALFX_PROFILER_ENABLED=true
-ENV SIGNALFX_PROFILER_MEMORY_ENABLED=true
-ENV SIGNALFX_METRICS_Process_ENABLED=true
+ENV CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
+ENV CORECLR_PROFILER_PATH=/.splunk-otel-dotnet/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
+ENV DOTNET_ADDITIONAL_DEPS=/.splunk-otel-dotnet/AdditionalDeps
+ENV DOTNET_SHARED_STORE=/.splunk-otel-dotnet/store
+ENV DOTNET_STARTUP_HOOKS=/.splunk-otel-dotnet/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll
+ENV OTEL_DOTNET_AUTO_PLUGINS="Splunk.OpenTelemetry.AutoInstrumentation.Plugin, Splunk.OpenTelemetry.AutoInstrumentation"
 
 ENTRYPOINT ["./cartservice", "start"]

--- a/src/cartservice/README.md
+++ b/src/cartservice/README.md
@@ -8,7 +8,7 @@ They make the application exercise different features available in the Splunk Ob
 ### Synthetic External DB Access
 
 These environment variables are used to simulate access to an external DB for some of the requests.
-The access to DB is wrapped by OpenTracing spans and the backend infers an external DB from these spans.
+The access to DB is wrapped by OpenTelemetry spans and the backend infers an external DB from these spans.
 
 - `EXTERNAL_DB_ACCESS_RATE`: float [0, 1], percentage of redis spans that will be turned into external database spans
 - `EXTERNAL_DB_ERROR_RATE`: float [0, 1], percentage of external DB access spans that will report error
@@ -17,8 +17,8 @@ The access to DB is wrapped by OpenTracing spans and the backend infers an exter
 
 ### Optimizations
 
-These environment variables are used to trigger behaviors on the application that affect its perfomance characteristics.
-Each optimization affects lantency, CPU, and memory in different ways.
+These environment variables are used to trigger behaviors on the application that affect its performance characteristics.
+Each optimization affects latency, CPU, and memory in different ways.
 Keep that in mind when interpreting their effect.
 All these environment variables are boolean.
 
@@ -50,4 +50,4 @@ popd
 If you want to send data to the backend set the following environment below when starting the `docker-compose`:
 
 - `SPLUNK_ACCESS_TOKEN`
-- `SIGNALFX_ENV`
+- `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=`

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -18,8 +18,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="OpenTracing" Version="0.12.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cartservice/tests/docker-compose.yaml
+++ b/src/cartservice/tests/docker-compose.yaml
@@ -10,13 +10,9 @@ services:
       - REDIS_ADDR=redis:6379
       - LISTEN_ADDR=0.0.0.0
       - PORT=7070
-      - SIGNALFX_ENDPOINT_URL=http://otel-collector:9411/api/v2/spans
-      - SIGNALFX_METRICS_ENDPOINT_URL=http://otel-collector:9943/v2/datapoint
-      - SIGNALFX_PROFILER_CALL_STACK_INTERVAL=1000
-      - SIGNALFX_PROFILER_ENABLED=true
-      - SIGNALFX_PROFILER_LOGS_ENDPOINT=http://otel-collector:4318/v1/logs
-      - SIGNALFX_RUNTIME_METRICS_ENABLED=true
-      - SIGNALFX_ENV
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+      - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=
+      - OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES=Cartservice
       - EXTERNAL_DB_NAME=Galactus.Postgres
       - EXTERNAL_DB_ACCESS_RATE=0.75
       - EXTERNAL_DB_MAX_DURATION_MILLIS=750

--- a/src/cartservice/tests/otel-config.yaml
+++ b/src/cartservice/tests/otel-config.yaml
@@ -37,11 +37,11 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [zipkin]
+      receivers: [otlp]
       processors: [batch]
       exporters: [logging, sapm]
     metrics:
-      receivers: [signalfx]
+      receivers: [otlp]
       processors: [batch]
       exporters: [logging, signalfx]
     logs:


### PR DESCRIPTION
Before changes
<img width="1407" alt="BeforeChanges" src="https://github.com/signalfx/microservices-demo/assets/5972917/6bd5fcd7-6495-4053-8b40-b0ff57392d43">

After changes:
<img width="1391" alt="AfterChanges" src="https://github.com/signalfx/microservices-demo/assets/5972917/cdfde2c9-4d9b-4918-aeec-e9b73514267f">

Main difference - lack of span for `grpc.request`. Splunk .NET OTel distribution does not have instrumentation for grpc server.

What is more. there will be not data for Always On Profiler (it is still not supported by this distro).
