### PR TITLE
[frontend] fix RUM instrumentation by updating deprecated properties

### DIFF
--- a/src/frontend/templates/header.html
+++ b/src/frontend/templates/header.html
@@ -16,7 +16,7 @@
     <link rel='shortcut icon' type='image/x-icon' href='/static/favicon.ico' />
     {{- if and $.rum_realm $.rum_auth }}
     <script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" type="text/javascript"></script>
-    <script>window.SplunkRum && window.SplunkRum.init({beaconUrl: "https://rum-ingest.{{ $.rum_realm }}.signalfx.com/v1/rum", rumAuth: "{{ $.rum_auth }}"{{ if $.rum_app_name }}, app: "{{ $.rum_app_name }}"{{ end }}{{ if $.rum_environment }}, environment: "{{ $.rum_environment }}"{{ end }}{{ if $.rum_debug }}, debug: "true"{{ end }}});</script>
+    <script>window.SplunkRum && window.SplunkRum.init({beaconEndpoint: "https://rum-ingest.{{ $.rum_realm }}.signalfx.com/v1/rum", rumAccessToken: "{{ $.rum_auth }}"{{ if $.rum_app_name }}, applicationName: "{{ $.rum_app_name }}"{{ end }}{{ if $.rum_environment }}, deploymentEnvironment: "{{ $.rum_environment }}"{{ end }}{{ if $.rum_debug }}, debug: "true"{{ end }}});</script>
     {{- end }}
 </head>
 


### PR DESCRIPTION
"frontend" uses the latest version of the RUM web sdk from CDN.  Earlier today, a new major
version was released (v1.0.x).  "frontend" has been using deprecated configurations
for SplunkRum.init which are no longer supported in v1.

This change updates the following deprecated configs based on
https://github.com/signalfx/splunk-otel-js-web/blob/main/CHANGELOG.md#100

 - beaconUrl -> beaconEndpoint
 - app -> applicationName
 - environment -> deploymentEnvironment
 - rumAuth -> rumAccessToken

Tested by following README steps to run services locally and verify that RUM data was getting ingested
when configured with a valid beacon endpoint URL and RUM access token.